### PR TITLE
Make createSchemas a protected method

### DIFF
--- a/src/main/java/com/buschmais/jqassistant/plugin/rdbms/impl/scanner/AbstractSchemaScannerPlugin.java
+++ b/src/main/java/com/buschmais/jqassistant/plugin/rdbms/impl/scanner/AbstractSchemaScannerPlugin.java
@@ -124,7 +124,7 @@ public abstract class AbstractSchemaScannerPlugin<I, D extends ConnectionDescrip
      * @return The list of created schema descriptors.
      * @throws java.io.IOException If an error occurs.
      */
-    private List<SchemaDescriptor> createSchemas(Catalog catalog, Store store) throws IOException {
+    protected List<SchemaDescriptor> createSchemas(Catalog catalog, Store store) throws IOException {
         List<SchemaDescriptor> schemaDescriptors = new ArrayList<>();
         Map<String, ColumnTypeDescriptor> columnTypes = new HashMap<>();
         Map<Column, ColumnDescriptor> allColumns = new HashMap<>();


### PR DESCRIPTION
We are using the RDBMS Plugin and would like to use a DataSource that is provided by us for scanning.

We tried using a custom plugin extending AbstractSchemaScanner, but we need to customize the connecting methods.
Therefore it would be great to be able to call createSchemas, but it is private.